### PR TITLE
volunteer_cnt change

### DIFF
--- a/src/main/java/com/spring/application/controller/ApplicationController.java
+++ b/src/main/java/com/spring/application/controller/ApplicationController.java
@@ -1,6 +1,8 @@
 package com.spring.application.controller;
 
 import java.net.http.HttpRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +14,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -113,4 +116,18 @@ public class ApplicationController {
         int applicationCheck = service.applicatoinCheck(applicationVO);
         return applicationCheck;
 	}
+	
+	@ResponseBody
+	 @PostMapping("/increaseUserVolCnt")
+	    public void increaseUserVolCnt(String[]  userIds) {
+		 	/*int result = 0;
+	        String url = "";
+	        result = service.increaseUserVolCnt(userIds);
+	        applicationVO.getVolunteer().setVolunteerId(volunteer.getVolunteerId());
+			if(result == 1) {
+				url = "/volunteer/adminVolunteer/";
+			}
+			return "redirect:" + url;*/
+		 	service.increaseUserVolCnt(userIds);
+	    }
 }

--- a/src/main/java/com/spring/application/dao/ApplicationDAO.java
+++ b/src/main/java/com/spring/application/dao/ApplicationDAO.java
@@ -26,4 +26,6 @@ public interface ApplicationDAO {
 	// 봉사 공고 신청 여부 확인
 	public int applicationCheck(ApplicationVO applicationVO);
 	
+	// 봉사 실행 여부에 따라 봉사 활동 증가
+	public int increaseUserVolCnt(String[] userIds);
 }

--- a/src/main/java/com/spring/application/service/ApplicationServcieImpl.java
+++ b/src/main/java/com/spring/application/service/ApplicationServcieImpl.java
@@ -52,4 +52,11 @@ public class ApplicationServcieImpl implements ApplicationService{
 		applicationCheck = applicationDAO.applicationCheck( applicatinoVO);
 		return applicationCheck;
 	}
+
+	@Override
+	public int increaseUserVolCnt(String[] userIds) {
+		int increaseUserVolCnt = 0;
+		increaseUserVolCnt = applicationDAO.increaseUserVolCnt(userIds);
+		return increaseUserVolCnt;
+	}
 }

--- a/src/main/java/com/spring/application/service/ApplicationService.java
+++ b/src/main/java/com/spring/application/service/ApplicationService.java
@@ -16,4 +16,6 @@ public interface ApplicationService {
 	public int applicationDelete(ApplicationVO applicationVO);
 	
 	public int applicatoinCheck(ApplicationVO applicatinoVO);
+	
+	public int increaseUserVolCnt(String[] userIds);
 }

--- a/src/main/java/com/spring/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/spring/volunteer/controller/VolunteerController.java
@@ -122,10 +122,4 @@ public class VolunteerController {
 		return "redirect:"+url;
 	}
 	
-	// progress 1 로 바꾸기
-	@PostMapping("/updateVolunteerProgress1") 
-	public ResponseEntity<String> updateVolunteerProgress1(VolunteerVO volunteerVO) {
-		service.updateVolunteerProgress1(volunteerVO);
-        return ResponseEntity.ok("volunteer_progress가 업데이트되었습니다.");
-    }
 }

--- a/src/main/resources/templates/query/application.xml
+++ b/src/main/resources/templates/query/application.xml
@@ -12,6 +12,7 @@
 		<association property="user">
 			<result column="user_id" property="userId" /> 
 			<result column="user_name" property="userName" /> 
+			<result column="user_volcnt" property="userVolcnt" />
 		</association> 
 		<association property="volunteer">
 			<result column="volunteer_id" property="volunteerId" /> 
@@ -57,4 +58,14 @@
 		USING (user_id)
 		WHERE user_id = #{user.userId} AND volunteer_id = #{volunteer.volunteerId}
 	</select>
+	
+	<update id="increaseUserVolCnt" parameterType="java.lang.String" >
+    UPDATE users
+    SET user_volcnt = user_volcnt + 1
+    WHERE user_id IN
+    <foreach collection="array" item="userId" open="(" separator="," close=")">
+        #{userId}
+    </foreach>
+</update>
+
 </mapper>

--- a/src/main/webapp/WEB-INF/views/admin/volunteer/adminVolunteerDetail.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/volunteer/adminVolunteerDetail.jsp
@@ -32,9 +32,10 @@
 			    	console.log(response);
 			        var list = '<ul>';
 			        $.each(response, function(index, item) {
-			            list += '<li>아이디: ' + item.user.userId + ', 성함: ' + item.user.userName + ', ';
-			            list += "참가<input type='radio' name='absent" + index + "' value='참여' checked />"
-			            list += "불참<input type='radio' name='absent" + index + "' value='불참' />"
+			        	var userId = item.user.userId
+			            list += '<li data-id=' + userId + '>아이디: ' +userId + ', 성함: ' + item.user.userName + ', ';
+			            list += "참여<input type='radio' name='attendance" + index + "' value='참여' checked />"
+			            list += "불참<input type='radio' name='attendance" + index + "' value='불참' />"
 			            list += '</li>';
 			        });
 			        list += '</ul>';
@@ -106,6 +107,36 @@
 					location.href="/volunteer/volunteerDelete?volunteerId="+volunteerId;
 				}
 			})
+			/* 참여 확인 클릭 시 이벤트 */
+			$("#submitBtn").on("click", function() {
+				var dataToSend = [];
+				
+				// "참여" 라디오 버튼 값만 처리
+				$("input[type='radio']:checked").each(function() {
+					console.log($(this).val());
+					if($(this).val ()	== "참여") {
+						var userId = $(this).closest('li').data('id');
+						dataToSend.push( userId );
+						console.log(typeof(dataToSend)); 
+					}
+				})
+				
+				// 서버로 데이터 전송
+				$.ajax({
+					url : '/application/increaseUserVolCnt',
+					method : 'POST',
+					//data : JSON.stringify(dataToSend),
+					data:"userIds="+dataToSend,
+					success : function(response) {
+						console.log(response);
+						alert("참여 확인 되었습니다.");
+					},
+					error: function(xhr, status, error) {
+						console.error(error);
+						alert("오류가 발생했습니다. 다시 시도해 주세요.");
+					}
+				})
+			})
 		})	
 	</script>
 <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
@@ -158,6 +189,7 @@
 					</div>
 					<div class="underline"></div>
 					<div id="appList"></div>
+					<button type="button"  id="submitBtn" >참여 확인</button>
 					<div class="underline"></div>
 					<div id="button">
 						<button type="button" id="updateBtn">수정</button>

--- a/src/test/java/com/spring/application/dao/ApplicatoinDAOTests.java
+++ b/src/test/java/com/spring/application/dao/ApplicatoinDAOTests.java
@@ -1,5 +1,9 @@
 package com.spring.application.dao;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -7,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.spring.application.vo.ApplicationVO;
+import com.spring.user.vo.UserVO;
 import com.spring.volunteer.vo.VolunteerVO;
 
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +92,7 @@ public class ApplicatoinDAOTests {
 		log.info("삭제된 행 : " + applicationDAO.applicationDelete(applicationVO));
 	}*/
 	
+	/*
 	@Test
 	public void applicationCheckTest() {
 		ApplicationVO applicationVO = new ApplicationVO();
@@ -94,5 +100,13 @@ public class ApplicatoinDAOTests {
 		applicationVO.getVolunteer().setVolunteerId(3);
 		int applicatinoCheck = applicationDAO.applicationCheck(applicationVO);
 		log.info("반환 결과 : " + applicatinoCheck);
+	} */
+	
+	/* */
+	@Test
+	public void testUpdateUserVolCnt() {
+		 // 테스트할 사용자 ID 목록
+		String[] userIds = {"member10", "member11"};
+		log.info("반환 갯수 : " + applicationDAO.increaseUserVolCnt(userIds));
 	}
 }


### PR DESCRIPTION
구현
봉사활동 공고 리스트 게시판
봉사활동 공고 리스트 게시판에서 공고 클릭시 공고 상세정보 페이지 이동
공고 상세정보 페이지
공고 신청 팝업화면 구현
관리자 게시판에서 봉사활동 공고 리스트 및 글쓰기 구현
관리자 게시판에서 들어간 상세정보에는 신청자 리스트를 볼 수 있게 구현
공고 신청 화면에서 신청 누르면 신청 정보 들어가게 설정
로그인 한 사람만 봉사 신청 가능
마이페이지에서 신청한 봉사 취소 가능
관리자 페이지에서 봉사 여부 체크시 봉사 횟수 올라가게 작업

미 구현
봉사 신청 마감일 지나면 봉사 신청 안되게 설정
공고 생성시 썸네일 넣는 기능 추가(이미지 테이블 쪽과 상의 해야함)